### PR TITLE
The fixes as discussed on the mailing list:

### DIFF
--- a/lib/DStarHeader.h
+++ b/lib/DStarHeader.h
@@ -25,7 +25,7 @@ class CDStarHeader {
 public:
 	//CDStarHeader();
 	CDStarHeader(unsigned char *in);
-	~CDStarHeader();
+//	~CDStarHeader();
 	const char *GetHeader();
 private:
 	unsigned char header[41];

--- a/lib/dstar_decode_bs_impl.cc
+++ b/lib/dstar_decode_bs_impl.cc
@@ -24,6 +24,7 @@
 
 #include <gnuradio/io_signature.h>
 #include "dstar_decode_bs_impl.h"
+#include <cstdio>
 
 namespace gr {
   namespace ambe3000 {


### PR DESCRIPTION
> Hi!
> 
> nope, I've tried the master branch only :/
> 
> but: syncing fails to build at all for me:
> 
> > make
> > [  3%] Building CXX object lib/CMakeFiles/gnuradio-ambe3000.dir/dstar_encode_sb_impl.cc.o
> > [  6%] Building CXX object lib/CMakeFiles/gnuradio-ambe3000.dir/DV3000U.cc.o
> > [  9%] Building CXX object lib/CMakeFiles/gnuradio-ambe3000.dir/DStarHeader.cc.o
> > [ 12%] Building CXX object lib/CMakeFiles/gnuradio-ambe3000.dir/DStarDecode.cc.o
> > [ 15%] Building CXX object lib/CMakeFiles/gnuradio-ambe3000.dir/dstar_decode_bs_impl.cc.o
> > /home/marcus/src/gr-ambe3000/lib/dstar_decode_bs_impl.cc: In constructor ‘gr::ambe3000::dstar_decode_bs_impl::dstar_decode_bs_impl(char_, int)’:
> > /home/marcus/src/gr-ambe3000/lib/dstar_decode_bs_impl.cc:48:71: error: ‘printf’ was not declared in this scope
> >    printf("%s is %s.\n", device, device_is_closed ? "closed" : "opened");
> >                                                                        ^
> > lib/CMakeFiles/gnuradio-ambe3000.dir/build.make:158: recipe for target 'lib/CMakeFiles/gnuradio-ambe3000.dir/dstar_decode_bs_impl.cc.o' failed
> > make[2]: *_\* [lib/CMakeFiles/gnuradio-ambe3000.dir/dstar_decode_bs_impl.cc.o] Error 1
> > CMakeFiles/Makefile2:137: recipe for target 'lib/CMakeFiles/gnuradio-ambe3000.dir/all' failed
> > make[1]: **\* [lib/CMakeFiles/gnuradio-ambe3000.dir/all] Error 2
> > Makefile:138: recipe for target 'all' failed
> > make: **\* [all] Error 2
> 
> After adding the necessary #include <cstdio> I got a linker error:
> 
> libgnuradio-ambe3000.so: undefined reference to `CDStarHeader::~CDStarHeader()'
> 
> A-ha! your DStarHeader.h declares a destructor, but you never implement it; so either remove that declaration in the header, or add an actual implementation!
> 
> With those modifications [1] instantiating ds_decode_bs works on the syncing branch for me.
> 
> Cheers,
> Marcus
